### PR TITLE
Add dark mode toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "npm test --prefix src/backend && npm test --prefix src/frontend -- --watchAll=false"
   },
   "repository": {
     "type": "git",

--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -8,10 +8,14 @@
   margin-left: 240px; /* space for sidebar */
   padding: 1rem;
   font-family: sans-serif;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  min-height: 100vh;
 }
 
 /* ─────────── Header / Menu Card ─────────── */
 .menu {
+  position: relative;
   padding: 1rem;
   justify-content: center;
   margin-bottom: 1rem;
@@ -57,7 +61,7 @@
   overflow: hidden;
   border-radius: 1rem;
   /* subtle frosted background; you can tweak the alpha */
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--glass-bg);
   box-shadow:
     0 6px 6px rgba(0, 0, 0, 0.2),
     0 0 20px rgba(0, 0, 0, 0.1);
@@ -77,7 +81,7 @@
   position: absolute;
   inset: 0;
   z-index: 1;
-  background: rgba(255, 255, 255, 0.25);
+  background: var(--glass-tint);
 }
 
 .liquidGlass-shine {
@@ -93,4 +97,16 @@
   position: relative;
   z-index: 3;
   width: 100%;
+}
+
+/* ─────────── Theme Toggle Button ─────────── */
+.theme-toggle {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: inherit;
 }

--- a/src/frontend/src/App.test.tsx
+++ b/src/frontend/src/App.test.tsx
@@ -1,9 +1,21 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+
+// Mock Chart.js adapter and chart components to avoid ESM parsing issues
+jest.mock('chartjs-adapter-dayjs-4/dist/chartjs-adapter-dayjs-4.esm', () => ({}));
+jest.mock('react-chartjs-2', () => ({
+  Line: () => <div data-testid="line-chart" />,
+  Bar: () => <div data-testid="bar-chart" />,
+}));
+jest.mock('axios');
+jest.mock('./components/HistoricalLineChart', () => () => <div data-testid="historical" />);
+jest.mock('./components/RecentBarChart', () => () => <div data-testid="recent" />);
+jest.mock('./components/MapView', () => ({ MapView: () => <div data-testid="map" /> }));
+
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders dashboard heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/311 Insight Dashboard/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import HistoricalLineChart from './components/HistoricalLineChart';
 import RecentBarChart    from './components/RecentBarChart';
 import { MapView }       from './components/MapView';
 import LiquidGlassWrapper from './components/LiquidGlassWrapper';
+import ThemeToggle from './components/ThemeToggle';
 
 function App() {
   return (
@@ -58,6 +59,7 @@ function App() {
         {/* Header card */}
         <LiquidGlassWrapper className="menu">
           <h1>311 Insight Dashboard</h1>
+          <ThemeToggle />
         </LiquidGlassWrapper>
 
         {/* exactly three columns, back to original layout */}

--- a/src/frontend/src/components/Sidebar.css
+++ b/src/frontend/src/components/Sidebar.css
@@ -4,8 +4,8 @@
   left: 0;
   width: 220px;
   height: 100vh;
-  background: linear-gradient(0deg, #ba54f5 0%, #e14eca 100%);
-  color: #fff;
+  background: var(--sidebar-bg);
+  color: var(--sidebar-color);
   padding-top: 60px;
   z-index: 1000;
 }
@@ -22,7 +22,7 @@
 .sidebar-link {
   display: flex;
   align-items: center;
-  color: #fff;
+  color: var(--sidebar-color);
   padding: 0.5rem 1rem;
   margin-bottom: 0.5rem;
   border-radius: 0.375rem;

--- a/src/frontend/src/components/ThemeToggle.tsx
+++ b/src/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,23 @@
+import React, { useEffect, useState } from 'react';
+
+const ThemeToggle: React.FC = () => {
+  const [theme, setTheme] = useState<string>(() => localStorage.getItem('theme') || 'light');
+
+  useEffect(() => {
+    document.body.classList.remove('light', 'dark');
+    document.body.classList.add(theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggle = () => {
+    setTheme(t => (t === 'light' ? 'dark' : 'light'));
+  };
+
+  return (
+    <button className="theme-toggle" onClick={toggle} aria-label="Toggle theme">
+      {theme === 'light' ? '🌙' : '☀️'}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -5,6 +5,30 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+
+body.light {
+  --bg-color: #ffffff;
+  --text-color: #000000;
+  --card-bg: #ffffff;
+  --card-shadow: rgba(0, 0, 0, 0.1);
+  --sidebar-bg: linear-gradient(0deg, #ba54f5 0%, #e14eca 100%);
+  --sidebar-color: #ffffff;
+  --glass-bg: rgba(255, 255, 255, 0.1);
+  --glass-tint: rgba(255, 255, 255, 0.25);
+}
+
+body.dark {
+  --bg-color: #121212;
+  --text-color: #e0e0e0;
+  --card-bg: #1e1e1e;
+  --card-shadow: rgba(0, 0, 0, 0.5);
+  --sidebar-bg: linear-gradient(0deg, #4a148c 0%, #1a237e 100%);
+  --sidebar-color: #ffffff;
+  --glass-bg: rgba(255, 255, 255, 0.05);
+  --glass-tint: rgba(255, 255, 255, 0.1);
 }
 
 code {
@@ -35,9 +59,9 @@ code {
 }
 
 .card {
-  background: #fff;
+  background: var(--card-bg);
   border-radius: 6px;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+  box-shadow: 0 2px 6px var(--card-shadow);
   padding: 1.5rem;
   margin-bottom: 2rem;
 }


### PR DESCRIPTION
## Summary
- introduce ThemeToggle component
- wire up theme toggle in App
- add dark/light CSS variables and styles
- style sidebar & glass effect with theme vars
- mock heavy modules for React tests
- update root test script to run backend and frontend tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c2de08a60832da91380185c2915fa