### PR TITLE
fix: apply saved theme early

### DIFF
--- a/src/frontend/public/index.html
+++ b/src/frontend/public/index.html
@@ -25,6 +25,12 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>React App</title>
+    <script>
+      (function() {
+        var theme = localStorage.getItem('theme') || 'light';
+        document.documentElement.setAttribute('data-theme', theme);
+      })();
+    </script>
   </head>
   <svg style="display: none">
     <filter id="glass-distortion" x="0%" y="0%" width="100%" height="100%" filterUnits="objectBoundingBox">

--- a/src/frontend/src/components/ThemeToggle.tsx
+++ b/src/frontend/src/components/ThemeToggle.tsx
@@ -4,8 +4,7 @@ const ThemeToggle: React.FC = () => {
   const [theme, setTheme] = useState<string>(() => localStorage.getItem('theme') || 'light');
 
   useEffect(() => {
-    document.body.classList.remove('light', 'dark');
-    document.body.classList.add(theme);
+    document.documentElement.setAttribute('data-theme', theme);
     localStorage.setItem('theme', theme);
   }, [theme]);
 

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -9,7 +9,7 @@ body {
   color: var(--text-color);
 }
 
-body.light {
+html[data-theme='light'] {
   --bg-color: #ffffff;
   --text-color: #000000;
   --card-bg: #ffffff;
@@ -20,7 +20,7 @@ body.light {
   --glass-tint: rgba(255, 255, 255, 0.25);
 }
 
-body.dark {
+html[data-theme='dark'] {
   --bg-color: #121212;
   --text-color: #e0e0e0;
   --card-bg: #1e1e1e;


### PR DESCRIPTION
## Summary
- avoid flash of unthemed content by setting `data-theme` on the `<html>` element before the page renders
- switch ThemeToggle to also use `data-theme`
- update CSS selectors

## Testing
- `npm test --prefix src/backend`
- `npm test --prefix src/frontend -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_684c37f9cb48832d9d15ae464f7e4c5a