### PR TITLE
Improve dashboard layout and navigation

### DIFF
--- a/src/data-ingestion/config.js
+++ b/src/data-ingestion/config.js
@@ -1,9 +1,6 @@
-cat << 'EOF' > src/data-ingestion/config.js
-// src/data-ingestion/config.js
 module.exports = {
   DOWNLOAD_URL: 'https://ckan0.cf.opendata.inter.prod-toronto.ca/dataset/2e54bc0e-4399-4076-b717-351df5918ae7/resource/f3db05ab-2588-4159-89f7-56c74d1d8201/download/sr2025.zip',
   LOCAL_ZIP: 'data/sr2025.zip',
   LOCAL_CSV_DIR: 'data/csv',
   CSV_FILENAME: 'sr2025.csv'
 };
-EOF

--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -20,7 +20,7 @@
 /* ─────────── Dashboard Grid (3 columns) ─────────── */
 .dashboard-grid {
   display: grid;
-  grid-template-columns: repeat(1, 3fr);
+  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
   gap: 1rem;
 }
 
@@ -32,6 +32,10 @@
   display: flex;
   flex-direction: column;
   background: transparent;
+}
+
+.map-card {
+  grid-column: 1 / -1;
 }
 
 /* ─────────── Date & Map Controls ─────────── */

--- a/src/frontend/src/components/AboutPage.tsx
+++ b/src/frontend/src/components/AboutPage.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function AboutPage() {
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h2>About</h2>
+      <p>
+        This dashboard visualizes Toronto 311 service requests. Explore the charts
+        and map to learn more about issues reported across the city.
+      </p>
+    </div>
+  );
+}

--- a/src/frontend/src/components/MapPage.tsx
+++ b/src/frontend/src/components/MapPage.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { MapView } from './MapView';
+
+export default function MapPage() {
+  return (
+    <div className="map-page">
+      <MapView />
+    </div>
+  );
+}

--- a/src/frontend/src/components/StatisticsPage.tsx
+++ b/src/frontend/src/components/StatisticsPage.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import HistoricalLineChart from './HistoricalLineChart';
+import YearlyBarChart from './YearlyBarChart';
+
+export default function StatisticsPage() {
+  return (
+    <div className="dashboard-grid">
+      <HistoricalLineChart />
+      <YearlyBarChart />
+    </div>
+  );
+}

--- a/src/frontend/src/index.tsx
+++ b/src/frontend/src/index.tsx
@@ -3,6 +3,9 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import Sidebar, { SidebarRoute } from './components/Sidebar';
+import MapPage from './components/MapPage';
+import StatisticsPage from './components/StatisticsPage';
+import AboutPage from './components/AboutPage';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import reportWebVitals from './reportWebVitals';
 
@@ -11,6 +14,9 @@ const root = ReactDOM.createRoot(
 );
 const routes: SidebarRoute[] = [
   { path: '/', name: 'Dashboard' },
+  { path: '/map', name: 'Map' },
+  { path: '/statistics', name: 'Statistics' },
+  { path: '/about', name: 'About' },
 ];
 
 root.render(
@@ -19,6 +25,9 @@ root.render(
       <Sidebar routes={routes} />
       <Routes>
         <Route path="/" element={<App />} />
+        <Route path="/map" element={<MapPage />} />
+        <Route path="/statistics" element={<StatisticsPage />} />
+        <Route path="/about" element={<AboutPage />} />
       </Routes>
     </BrowserRouter>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- improve dashboard grid layout so map spans the width
- add Map, Statistics, and About pages
- update sidebar navigation with the new routes
- correct `config.js` for data ingestion

## Testing
- `npm test` *(fails: Error: no test specified)*
- `cd src/frontend && npm test` *(fails: react-scripts: not found)*
- `cd src/backend && npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8cd02958832d9456500d57981e22