### PR TITLE
Improve stats layout and add resolution chart

### DIFF
--- a/src/backend/app.js
+++ b/src/backend/app.js
@@ -163,6 +163,22 @@ app.get('/api/requests/yearly_top', async (req, res) => {
   }
 });
 
+// 4. Resolution status counts
+app.get('/api/requests/resolution', async (req, res) => {
+  try {
+    const { rows } = await pool.query(
+      `SELECT status, COUNT(*)::INT AS count
+       FROM requests
+       GROUP BY status
+       ORDER BY count DESC`
+    );
+    res.json(rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
 // 3. Map data (unchanged)
 app.get('/api/requests/map', async (req, res) => {
   const category = req.query.category;

--- a/src/backend/tests/app.test.js
+++ b/src/backend/tests/app.test.js
@@ -98,6 +98,15 @@ describe('🚀 API Endpoints', () => {
     expect(res.statusCode).toBe(400);
     expect(res.body).toHaveProperty('error');
   });
+
+  test('GET /api/requests/resolution returns status counts', async () => {
+    poolMock.query.mockResolvedValueOnce({
+      rows: [{ status: 'Closed', count: 5 }]
+    });
+    const res = await request(app).get('/api/requests/resolution');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual([{ status: 'Closed', count: 5 }]);
+  });
 });
 
 

--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -5,9 +5,13 @@
 
 /* ─────────── Base App Layout ─────────── */
 .App {
+  font-family: sans-serif;
+}
+
+/* shared layout for all pages */
+.page-content {
   margin-left: 240px; /* space for sidebar */
   padding: 1rem;
-  font-family: sans-serif;
 }
 
 /* ─────────── Header / Menu Card ─────────── */
@@ -20,7 +24,7 @@
 /* ─────────── Dashboard Grid (3 columns) ─────────── */
 .dashboard-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   gap: 1rem;
 }
 
@@ -36,6 +40,14 @@
 
 .map-card {
   grid-column: 1 / -1;
+}
+
+.historical-line-chart {
+  grid-column: span 2;
+}
+
+.map-page {
+  height: 100vh;
 }
 
 /* ─────────── Date & Map Controls ─────────── */

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -23,14 +23,14 @@ function App() {
           <feDisplacementMap in="SourceGraphic" in2="softMap" scale="150" xChannelSelector="R" yChannelSelector="G" />
         </filter>
       </svg>
-      <div className="App">
+      <div className="App page-content">
         <LiquidGlassWrapper className="menu">
           <h1>311 Insight Dashboard</h1>
         </LiquidGlassWrapper>
         <div className="dashboard-grid">
           <HistoricalLineChart />
           <YearlyBarChart />
-          <MapView />
+          <MapView height="60vh" />
         </div>
       </div>
     </>

--- a/src/frontend/src/api/index.ts
+++ b/src/frontend/src/api/index.ts
@@ -6,6 +6,7 @@ export interface RecentItem { request_type: string; count: number; }
 export interface HistoricalItem { date: string; request_type?: string; count: number; }
 export interface Feature { type: 'Feature'; properties: { postal_area: string; count: number }; geometry: any; }
 export interface FeatureCollection { type: 'FeatureCollection'; features: Feature[]; }
+export interface StatusCount { status: string; count: number; }
 
 export function getRecent(minutes = 60, types?: string[]) {
   const params: any = { minutes };
@@ -30,5 +31,11 @@ export function getMapData(category: string) {
 export function getYearlyTop(year: number) {
   return axios
     .get<RecentItem[]>(`${BASE}/api/requests/yearly_top`, { params: { year } })
+    .then(res => res.data);
+}
+
+export function getStatusCounts() {
+  return axios
+    .get<StatusCount[]>(`${BASE}/api/requests/resolution`)
     .then(res => res.data);
 }

--- a/src/frontend/src/components/AboutPage.tsx
+++ b/src/frontend/src/components/AboutPage.tsx
@@ -2,12 +2,35 @@ import React from 'react';
 
 export default function AboutPage() {
   return (
-    <div style={{ padding: '1rem' }}>
-      <h2>About</h2>
+    <div className="page-content">
+      <h2>About this project</h2>
       <p>
-        This dashboard visualizes Toronto 311 service requests. Explore the charts
-        and map to learn more about issues reported across the city.
+        311 Insight Dashboard is an open source tool for exploring Toronto service
+        requests. It combines statistics and geospatial data to highlight trends
+        across the city.
       </p>
+      <h3>Contact Us</h3>
+      <form onSubmit={e => { e.preventDefault(); alert('Thanks for your message!'); }}>
+        <div>
+          <label>
+            Name:<br />
+            <input type="text" required />
+          </label>
+        </div>
+        <div>
+          <label>
+            Email:<br />
+            <input type="email" required />
+          </label>
+        </div>
+        <div>
+          <label>
+            Message:<br />
+            <textarea required rows={4} />
+          </label>
+        </div>
+        <button type="submit">Send</button>
+      </form>
     </div>
   );
 }

--- a/src/frontend/src/components/MapPage.tsx
+++ b/src/frontend/src/components/MapPage.tsx
@@ -3,8 +3,8 @@ import { MapView } from './MapView';
 
 export default function MapPage() {
   return (
-    <div className="map-page">
-      <MapView />
+    <div className="page-content map-page">
+      <MapView height="80vh" />
     </div>
   );
 }

--- a/src/frontend/src/components/MapView.tsx
+++ b/src/frontend/src/components/MapView.tsx
@@ -17,7 +17,11 @@ const TIMEFRAMES = [
 
 const DEFAULT_CENTER: [number, number] = [43.65, -79.38];
 
-export function MapView() {
+interface MapViewProps {
+  height?: string;
+}
+
+export function MapView({ height = '60vh' }: MapViewProps) {
   const [types, setTypes] = useState<string[]>([]);
   const [category, setCategory] = useState<string>('');
   const [timeframe, setTimeframe] = useState<number>(TIMEFRAMES[0].minutes);
@@ -94,7 +98,7 @@ export function MapView() {
           </select>
         </label>
       </div>
-      <MapContainer center={DEFAULT_CENTER} zoom={11} style={{ height: '400px', width: '100%' }} >
+      <MapContainer center={DEFAULT_CENTER} zoom={11} style={{ height, width: '100%' }} >
         <TileLayer attribution="&copy; OpenStreetMap" url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
         {validFeatures.map((f, i) => {
           const coord = centroidData[f.properties.postal_area] as [number, number];

--- a/src/frontend/src/components/StatisticsPage.tsx
+++ b/src/frontend/src/components/StatisticsPage.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
 import HistoricalLineChart from './HistoricalLineChart';
 import YearlyBarChart from './YearlyBarChart';
+import StatusBarChart from './StatusBarChart';
 
 export default function StatisticsPage() {
   return (
-    <div className="dashboard-grid">
-      <HistoricalLineChart />
-      <YearlyBarChart />
+    <div className="page-content">
+      <div className="dashboard-grid">
+        <HistoricalLineChart />
+        <YearlyBarChart />
+      </div>
+      <StatusBarChart />
     </div>
   );
 }

--- a/src/frontend/src/components/StatusBarChart.tsx
+++ b/src/frontend/src/components/StatusBarChart.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from 'react';
+import { Bar } from 'react-chartjs-2';
+import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend } from 'chart.js';
+import LiquidGlassWrapper from './LiquidGlassWrapper';
+import axios from 'axios';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+interface StatusItem { status: string; count: number; }
+
+export default function StatusBarChart() {
+  const [data, setData] = useState<StatusItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    axios
+      .get<StatusItem[]>(`${process.env.REACT_APP_API_URL}/api/requests/resolution`)
+      .then(res => setData(res.data))
+      .catch(() => setError('Failed to load resolution data'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const chartData = {
+    labels: data.map(d => d.status),
+    datasets: [
+      {
+        label: 'Requests',
+        data: data.map(d => d.count),
+        backgroundColor: '#5856d6',
+      },
+    ],
+  };
+
+  return (
+    <LiquidGlassWrapper className="chart-card">
+      {error && <div className="error">{error}</div>}
+      {loading ? <div>Loading resolution data…</div> : <Bar data={chartData} />}
+    </LiquidGlassWrapper>
+  );
+}


### PR DESCRIPTION
## Summary
- adjust dashboard grid to dedicate two columns for the historical line chart
- make map cards taller and allow custom map height
- ensure pages leave space for the sidebar and give Map page a full-screen map
- create a new Statistics page chart showing request resolution counts
- expose `/api/requests/resolution` endpoint
- provide a better About page with a simple contact form
- test new backend endpoint

## Testing
- `npm test --prefix src/backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c920fb988832d9486584961648743