### PR TITLE
Add spinning Toronto logo for loading states

### DIFF
--- a/src/frontend/src/components/HistoricalLineChart.tsx
+++ b/src/frontend/src/components/HistoricalLineChart.tsx
@@ -4,6 +4,7 @@ import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement
 import 'chartjs-adapter-dayjs-4/dist/chartjs-adapter-dayjs-4.esm';
 import axios from 'axios';
 import LiquidGlassWrapper from './LiquidGlassWrapper';
+import LoadingSpinner from './LoadingSpinner';
 import dayjs from 'dayjs';
 import { useRequestTypes } from '../hooks/useRequestTypes';
 import Select from 'react-select';
@@ -155,7 +156,7 @@ export default function HistoricalLineChart() {
       {error && <div className="error">{error}</div>}
 
       {loading ? (
-        <div>Loading historical data…</div>
+        <LoadingSpinner text="Loading historical data…" />
       ) : (
         <Line data={chartData} options={options} />
       )}

--- a/src/frontend/src/components/LoadingSpinner.css
+++ b/src/frontend/src/components/LoadingSpinner.css
@@ -1,0 +1,22 @@
+.loading-spinner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.loading-spinner img {
+  width: 48px;
+  height: 48px;
+  animation: logo-spin 1s linear infinite;
+}
+
+.loading-text {
+  margin-top: 0.5rem;
+}
+
+@keyframes logo-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}

--- a/src/frontend/src/components/LoadingSpinner.tsx
+++ b/src/frontend/src/components/LoadingSpinner.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import './LoadingSpinner.css';
+
+interface LoadingSpinnerProps {
+  text?: string;
+}
+
+const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({ text }) => (
+  <div className="loading-spinner">
+    <img src={process.env.PUBLIC_URL + '/logo.svg'} alt="Loading" />
+    {text && <div className="loading-text">{text}</div>}
+  </div>
+);
+
+export default LoadingSpinner;

--- a/src/frontend/src/components/MapView.tsx
+++ b/src/frontend/src/components/MapView.tsx
@@ -6,6 +6,7 @@ import axios from 'axios';
 import { FeatureCollection } from '../api';
 import centroidData from '../data/postal_centroids_full.json';
 import LiquidGlassWrapper from './LiquidGlassWrapper';
+import LoadingSpinner from './LoadingSpinner';
 
 const TIMEFRAMES = [
   { label: 'Last 1 hour', minutes: 60 },
@@ -56,8 +57,8 @@ export function MapView({ height = '60vh' }: MapViewProps) {
       .finally(() => setLoading(false));
   }, [category, timeframe]);
 
-  if (!types.length) return <div>Loading categories…</div>;
-  if (loading) return <div>Loading map…</div>;
+  if (!types.length) return <LoadingSpinner text="Loading categories…" />;
+  if (loading) return <LoadingSpinner text="Loading map…" />;
   if (error) return <div>{error}</div>;
   if (!geo?.features.length)
     return <div>No data for selected category/timeframe.</div>;

--- a/src/frontend/src/components/StatusBarChart.tsx
+++ b/src/frontend/src/components/StatusBarChart.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Bar } from 'react-chartjs-2';
 import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend } from 'chart.js';
 import LiquidGlassWrapper from './LiquidGlassWrapper';
+import LoadingSpinner from './LoadingSpinner';
 import axios from 'axios';
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
@@ -35,7 +36,11 @@ export default function StatusBarChart() {
   return (
     <LiquidGlassWrapper className="chart-card">
       {error && <div className="error">{error}</div>}
-      {loading ? <div>Loading resolution data…</div> : <Bar data={chartData} />}
+      {loading ? (
+        <LoadingSpinner text="Loading resolution data…" />
+      ) : (
+        <Bar data={chartData} />
+      )}
     </LiquidGlassWrapper>
   );
 }

--- a/src/frontend/src/components/YearlyBarChart.tsx
+++ b/src/frontend/src/components/YearlyBarChart.tsx
@@ -10,6 +10,7 @@ import {
   Legend,
 } from 'chart.js';
 import LiquidGlassWrapper from './LiquidGlassWrapper';
+import LoadingSpinner from './LoadingSpinner';
 import { getYearlyTop, RecentItem } from '../api';
 import { exportToCSV } from '../utils/exportToCSV';
 
@@ -54,7 +55,11 @@ export default function YearlyBarChart() {
         />
       </label>
       {error && <div className="error">{error}</div>}
-      {loading ? <div>Loading yearly data…</div> : <Bar data={chartData} />}
+      {loading ? (
+        <LoadingSpinner text="Loading yearly data…" />
+      ) : (
+        <Bar data={chartData} />
+      )}
       <button onClick={() => exportToCSV(data, ['request_type', 'count'], 'yearly_top.csv')}>
         Export to CSV
       </button>


### PR DESCRIPTION
## Summary
- add `LoadingSpinner` component that displays the logo and spins
- show spinner instead of plain text while charts and map load

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ebeeb7304832d85e72e485d819154