### PR TITLE
Use skyline svg for loading

### DIFF
--- a/src/frontend/src/components/LoadingSpinner.css
+++ b/src/frontend/src/components/LoadingSpinner.css
@@ -6,17 +6,32 @@
   padding: 1rem;
 }
 
-.loading-spinner img {
-  width: 48px;
-  height: 48px;
-  animation: logo-spin 1s linear infinite;
+
+.skyline-wrapper {
+  width: 200px;
+  overflow: hidden;
+}
+
+.skyline-progress {
+  width: 0;
+  overflow: hidden;
+  animation: skyline-fill 2s linear infinite;
+}
+
+.skyline-progress img {
+  width: 100%;
+  display: block;
 }
 
 .loading-text {
   margin-top: 0.5rem;
 }
 
-@keyframes logo-spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
+@keyframes skyline-fill {
+  from {
+    width: 0;
+  }
+  to {
+    width: 100%;
+  }
 }

--- a/src/frontend/src/components/LoadingSpinner.tsx
+++ b/src/frontend/src/components/LoadingSpinner.tsx
@@ -7,7 +7,11 @@ interface LoadingSpinnerProps {
 
 const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({ text }) => (
   <div className="loading-spinner">
-    <img src={process.env.PUBLIC_URL + '/logo.svg'} alt="Loading" />
+    <div className="skyline-wrapper">
+      <div className="skyline-progress">
+        <img src={process.env.PUBLIC_URL + '/Skyline.svg'} alt="Loading" />
+      </div>
+    </div>
     {text && <div className="loading-text">{text}</div>}
   </div>
 );


### PR DESCRIPTION
## Summary
- redesign `LoadingSpinner` to animate Skyline.svg
- implement CSS animation that reveals skyline from left to right

## Testing
- `npm test` *(fails: Error: no test specified)*
- `cd src/frontend && npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ec1585b8c832db1e2c212973807b2