### PR TITLE
Enable background page caching

### DIFF
--- a/src/frontend/src/components/PageCache.tsx
+++ b/src/frontend/src/components/PageCache.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import App from '../App';
+import MapPage from './MapPage';
+import StatisticsPage from './StatisticsPage';
+import AboutPage from './AboutPage';
+
+const pages: Record<string, JSX.Element> = {
+  '/': <App />,
+  '/map': <MapPage />,
+  '/statistics': <StatisticsPage />,
+  '/about': <AboutPage />,
+};
+
+export default function PageCache() {
+  const location = useLocation();
+  const [loaded, setLoaded] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!loaded.includes(location.pathname) && pages[location.pathname]) {
+      setLoaded(prev => [...prev, location.pathname]);
+    }
+  }, [location.pathname, loaded]);
+
+  useEffect(() => {
+    const remaining = Object.keys(pages).filter(p => !loaded.includes(p));
+    if (!remaining.length) return;
+    const timer = setTimeout(() => {
+      setLoaded(prev => [...prev, remaining[0]]);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [loaded]);
+
+  return (
+    <>
+      {Object.entries(pages).map(([path, element]) =>
+        loaded.includes(path) ? (
+          <div key={path} style={{ display: path === location.pathname ? 'block' : 'none' }}>
+            {element}
+          </div>
+        ) : null
+      )}
+    </>
+  );
+}

--- a/src/frontend/src/index.tsx
+++ b/src/frontend/src/index.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
-import App from './App';
 import Sidebar, { SidebarRoute } from './components/Sidebar';
-import MapPage from './components/MapPage';
-import StatisticsPage from './components/StatisticsPage';
-import AboutPage from './components/AboutPage';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import PageCache from './components/PageCache';
+import { BrowserRouter } from 'react-router-dom';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(
@@ -23,12 +20,7 @@ root.render(
   <React.StrictMode>
     <BrowserRouter>
       <Sidebar routes={routes} />
-      <Routes>
-        <Route path="/" element={<App />} />
-        <Route path="/map" element={<MapPage />} />
-        <Route path="/statistics" element={<StatisticsPage />} />
-        <Route path="/about" element={<AboutPage />} />
-      </Routes>
+      <PageCache />
     </BrowserRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- add `PageCache` component to keep pages mounted once loaded
- switch router to use `PageCache`

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ec3e7d818832db16c6edc219ae2c6